### PR TITLE
Oprava poradu co nemaji url cele-dily

### DIFF
--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -159,6 +159,10 @@ def list_episodes():
             (plugin.url_for(get_category, show_url=url), list_item, True))
         url = plugin.args["show_url"][0] + "/videa/cele-dily"
     soup = get_page(url)
+    
+    if soup.find("div", "c-article-wrapper") is None:
+    	url = plugin.args["show_url"][0] + "/videa"
+    	soup = get_page(url)
     articles = soup.find(
         "div", "c-article-wrapper").find_all("article", "c-article")
     count = 0


### PR DESCRIPTION
Ahoj web novaplus je dost nekonzistentni a nektere porady nemaji vubec url pro cele-dily (konkretne porad O me se neboj). Tak jsem pridal kontrolu prazdneho objektu. Byl to rychly fix vice nemam cas. 